### PR TITLE
Fix tooltop display

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,6 @@ module.exports = class EmojiMegatip extends Plugin {
         if(atBottom) {
           n.classList.remove('tooltip-top');
           n.classList.add('tooltip-bottom');
-          n.style.top = (Number(n.style.top.replace("px", "")) + heightdiff/2) + "px";
-        } else {
-          n.style.top = (Number(n.style.top.replace("px", "")) - heightdiff) + "px";
         }
         n.style.textAlign = "center";
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emojimegatip",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "author": "Snazzah",
   "description": "Adds the biggest version of the emoji you are hovering over.",


### PR DESCRIPTION
Discord changed something so that tooltips no longer have a top style, meaning that this plugin would cause the tooltips to appear at ~-133px (above the screen)